### PR TITLE
Resolves critique app Pages Resources

### DIFF
--- a/.github/workflows/critique-prod.yml
+++ b/.github/workflows/critique-prod.yml
@@ -41,6 +41,8 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
       - name: Install critique
         run: npm ci
+      - name: Clean output
+        run: rm -rf ./out
       - name: Build critique
         run: npm run build --if-present
       - name: Check output
@@ -49,9 +51,40 @@ jobs:
             echo 'Error: ./out directory not found. Build may have failed.'
             exit 1
           fi
-      - name: Rewrite paths
+      - name: List output
+        run: ls -1 ./out
+      - name: Check next
         run: |
-          find ./out -name '*.html' -exec sed -i 's|"/_next/|"/stacked/_next/|g' {} +
+          if [ ! -d './out/_next' ]; then
+            echo 'Error: ./out/_next directory not found.'
+            exit 1
+          fi
+      - name: List next
+        run: ls -1 ./out/_next
+      - name: Check static
+        run: |
+          if [ ! -d './out/_next/static' ]; then
+            echo 'Error: ./out/_next/static directory not found.'
+            exit 1
+          fi
+      - name: List static
+        run: ls -1 ./out/_next/static
+      - name: Check chunks
+        run: |
+          if [ ! -d './out/_next/static/chunks' ]; then
+            echo 'Error: ./out/_next/static/chunks directory not found.'
+            exit 1
+          fi
+      - name: List chunks
+        run: ls -1 ./out/_next/static/chunks
+      - name: Check media
+        run: |
+          if [ ! -d './out/_next/static/media' ]; then
+            echo 'Error: ./out/_next/static/media directory not found.'
+            exit 1
+          fi
+      - name: List media
+        run: ls -1 ./out/_next/static/media
       - name: Test critique
         run: npm test
       - name: Upload critique

--- a/.github/workflows/critique-test.yml
+++ b/.github/workflows/critique-test.yml
@@ -29,6 +29,8 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
       - name: Install critique
         run: npm ci
+      - name: Clean output
+        run: rm -rf ./out
       - name: Build critique
         run: npm run build --if-present
       - name: Check output
@@ -37,8 +39,39 @@ jobs:
             echo 'Error: ./out directory not found. Build may have failed.'
             exit 1
           fi
-      - name: Rewrite paths
+      - name: List output
+        run: ls -1 ./out
+      - name: Check next
         run: |
-          find ./out -name '*.html' -exec sed -i 's|"/_next/|"/stacked/_next/|g' {} +
+          if [ ! -d './out/_next' ]; then
+            echo 'Error: ./out/_next directory not found.'
+            exit 1
+          fi
+      - name: List next
+        run: ls -1 ./out/_next
+      - name: Check static
+        run: |
+          if [ ! -d './out/_next/static' ]; then
+            echo 'Error: ./out/_next/static directory not found.'
+            exit 1
+          fi
+      - name: List static
+        run: ls -1 ./out/_next/static
+      - name: Check chunks
+        run: |
+          if [ ! -d './out/_next/static/chunks' ]; then
+            echo 'Error: ./out/_next/static/chunks directory not found.'
+            exit 1
+          fi
+      - name: List chunks
+        run: ls -1 ./out/_next/static/chunks
+      - name: Check media
+        run: |
+          if [ ! -d './out/_next/static/media' ]; then
+            echo 'Error: ./out/_next/static/media directory not found.'
+            exit 1
+          fi
+      - name: List media
+        run: ls -1 ./out/_next/static/media
       - name: Test critique
         run: npm test


### PR DESCRIPTION
## Summary
Resolves asset paths that are not found because the resources must be referenced with explicit subdirectory.

## Description
Troubleshoots problems with critique app interactivity and style on Pages deployment. Investigates certain static resources are not found.

## Changes
- Removes asset path rewrite and tests for presence of next resources

## Details
`critique-prod` deploy was successful and there is still a problem with the page interactions and style.  There is a bit more information after two runs and perhaps there is a small change that works. 

It seems that the page is deployed to a url with the repository name `<pages-uri>/stacked/`, not the app directory name (one page per repo) so it expects the resources to be in the `stacked/_next/static/media` and `stacked/_next/static/chunks`.  Browse `<pages-uri>/critique/` and page does not exist on GitHub.

First attempt
> The page is not interactive and has no styles. 🔴 ❌ 
> 
> `_next/static/media`
> `net::ERR_ABORTED 404 (Not Found)`
> 
> `_next/static/chunks`
> `The resource was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is preloaded intentionally.` 

Second attempt
> The page is not interactive and has no styles. 🔴 ❌ 
> 
> `critique/_next/static/media`
> `net::ERR_ABORTED 404 (Not Found)`
> 
> `critique/_next/static/chunks`
> `The resource was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is preloaded intentionally.` 

Page directory `/stacked/`.. not `/critique/`.

There is another potential problem that needs to be mitigated prior to the next deployment.

> After inspection of the currently deployed GitHub Pages site (with `/critique/_next/` paths) there seems to be missing resources.  There is no `_next` directory in the page tree and there is nothing else except for the `stacked/` index html.
> 
> GitHub Pages (deployed with `critique-deploy`)
> - Browser Inspsector > Sources > Page displays with the page tree as:
> -  Top > <github-pages-url> > stacked > stacked/
> ```
> - top
>   - <github-codespace-url-port>
>     - stacked
>       - stacked/
> ```
> Codespaces Port (`npm run dev`)
> - Browser Inspsector > Sources > Page displays with the page tree as:
> ```
> - top
>   - <github-codespace-url-port>
>     - (index)
>     -  _next
> ```

## Criteria
- Given the critique app has been deployed, when browsing the pages url, then then critique should display with correct styles and expected interactive behavior

## Steps
#### Reproduce critique app style and script problems with GitHub Pages
1. Browse `<codespace_id>-3000.app.github.dev`
  - Shows message field and button with style
  - Takes inputs in the message field
  - Shows message field input in chat log on submit
2. Browse `<pages_uri>/stacked/`
  - Shows message field and button without style
  - Takes inputs in the message field
  - Does not show message field input in chat log on submit

## Tests
#### View Action Workflow Tests
1. Browse repository name, click Actions
  - Shows Actions
2. Click the name of the run to see the workflow run summary
  - Shows run summary with Success
3. Review PR details
  - Shows run for critique-test
4. Approve and Merge PR
  - Shows run for critique-prod
#### View critique app hosted by GitHub Pages
1. Browse `stacked/settings/pages` for url and site details
- Shows critique app url and site details 
2. Browse critique via Pages
  - Shows text field with `Enter an idea` placeholder text
  - Shows with dark background with field and button in the center
3. Select text field and type text in the field
  - Takes inputs and displays `thinking...`
4. Select Submit with text in the field
  - Submits text in field on button click and shows text instead of `thinking...`
5. Select text in the field
  - Takes inputs in the text field and displays `thinking...` instead of submitted text
6. Enter text in the field and select Submit
  - Submits changed text field on button click and shows changed text