### PR TITLE
Resolves critique app url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Stacked - A Monorepo
 
 `critique` contains a web application that allows users to prompt an AI agent to critique a creative idea so they can get feedback on a proposal, such as, objectively if the idea is novel, viable, or valuable.
 
-[critique app](https://https://matthewctechnology.github.io/stacked/) is hosted on GitHub Pages and can be browsed without a development environment.
+[critique app](https://matthewctechnology.github.io/stacked/) is hosted on GitHub Pages and can be browsed without a development environment.
 
 ## Quickstart
 


### PR DESCRIPTION
## Summary
Resolves critique app url in readme so that it navigates to the GitHub Pages hosted application properly.

## Description
Resolves critique app url in readme has an incorrect url.  There are two instances of `https://` in the string, i.e. `https://https://`.

## Design
- Removes `https://` in `critique app` url in readme
- Updates readme with Playwright instead of SuperTest

## Acceptance Criteria
- Given stacked readme is viewed, when the critique app link is clicked, then the browser displays the critique app and not display `This site can’t be reached. Check if there is a typo in https.`

## Tests
View Stacked Readme and browse critique app
1. Browse `github.com/<user>/<repository>`
  - Shows Readme
  - Shows Playwright
  - Shows `critique app is hosted on GitHub Pages and can be browsed without a development environment.` 
  - Shows `critique app` link with two instances of `https://`
2. Browse `https://https://<user>.github.io/<repository>`, or use the `critique app` link
  - Shows `This site can’t be reached`
  - Does not show critique app
3. Browse `https://<user>.github.io/<repository>`
  - Shows critique app