### PR TITLE
Refactor critique App Tests with Jest Dom

### DIFF
--- a/critique/package-lock.json
+++ b/critique/package-lock.json
@@ -20,6 +20,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
+        "@types/jest": "^30.0.0",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1714,6 +1715,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+      "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -2002,6 +2013,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/globals": {
@@ -3017,6 +3038,237 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/expect-utils": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.2.0.tgz",
+      "integrity": "sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/types": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
+      "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
+      "version": "0.34.45",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.45.tgz",
+      "integrity": "sha512-qJcFVfCa5jxBFSuv7S5WYbA8XdeCPmhnaVVfX/2Y6L8WYg8sk3XY2+6W0zH+3mq1Cz+YC7Ki66HfqX6IHAwnkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ci-info": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+      "integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/jest/node_modules/expect": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz",
+      "integrity": "sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.2.0",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.2.0",
+        "jest-message-util": "30.2.0",
+        "jest-mock": "30.2.0",
+        "jest-util": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-diff": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
+      "integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.0.1",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.2.0.tgz",
+      "integrity": "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.2.0",
+        "pretty-format": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-message-util": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+      "integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.2.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "micromatch": "^4.0.8",
+        "pretty-format": "30.2.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-mock": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
+      "integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "jest-util": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-util": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+      "integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/jsdom": {
       "version": "21.1.7",

--- a/critique/package.json
+++ b/critique/package.json
@@ -23,6 +23,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@types/jest": "^30.0.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/critique/test/app/page.test.tsx
+++ b/critique/test/app/page.test.tsx
@@ -1,8 +1,9 @@
-import { describe, expect, jest, test } from '@jest/globals';
+import { describe, jest, test } from '@jest/globals';
 import Home from '../../src/app/page';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
+import '@testing-library/jest-dom';
 
 
 jest.mock('../../src/app/useChatReducer', () => {
@@ -64,26 +65,22 @@ jest.mock('../../src/app/useChatReducer', () => {
 describe('Home', () => {
   test('should display input field', () => {
     render(<Home />);
-    const expected = 'enter an idea';
-    const received = screen.getByPlaceholderText(expected).getAttribute('placeholder');
-
-    expect(received).toEqual(expected);
+    const input = screen.getByPlaceholderText('enter an idea');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('placeholder', 'enter an idea');
   });
 
   test('should display submit button', () => {
     render(<Home />);
-    const expected = 'submit';
-    const received = screen.getByRole('button', { name: 'submit' }).textContent;
-
-    expect(received).toEqual(expected);
+    const button = screen.getByRole('button', { name: 'submit' });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('submit');
   });
 
   test('should display disclaimer', () => {
     render(<Home />);
-    const expected = 'unvalidated responses inferred at individual risk';
-    const received = screen.queryByText(expected)?.textContent;
-
-    expect(received).toEqual(expected);
+    const disclaimer = screen.getByText('unvalidated responses inferred at individual risk');
+    expect(disclaimer).toBeInTheDocument();
   });
 
   test('should display thinking while loading', async () => {
@@ -94,9 +91,9 @@ describe('Home', () => {
     await userEvent.type(inputField, 'an idea');
     fireEvent.click(button);
 
-    expect(screen.queryByText('thinking...')).not.toBeNull();
+    expect(screen.getByText('thinking...')).toBeVisible();
     await waitFor(() => {
-      expect(screen.queryByText('thinking...')).toBeNull();
+      expect(screen.queryByText('thinking...')).not.toBeInTheDocument();
     });
   });
 
@@ -108,9 +105,9 @@ describe('Home', () => {
     await userEvent.type(inputField, 'an idea');
     fireEvent.click(button);
 
-    expect(screen.getByTestId('user').textContent).toBe('an idea');
+    expect(screen.getByTestId('user')).toHaveTextContent('an idea');
     await waitFor(() => {
-      expect(screen.getByTestId('ai')).not.toBeNull();
+      expect(screen.getByTestId('ai')).toBeInTheDocument();
     });
   });
 
@@ -123,8 +120,7 @@ describe('Home', () => {
     fireEvent.click(button);
 
     await waitFor(() => {
-      expect(inputField.textContent).toBe('');
-      expect(inputField.textContent).not.toBe('another idea');
+      expect(inputField).toHaveValue('');
     });
   });
 
@@ -134,8 +130,8 @@ describe('Home', () => {
     const button = screen.getByRole('button', { name: 'submit' }) as HTMLButtonElement;
 
     await userEvent.type(inputField, ' ');
-    expect(button.disabled).toBe(true);
-    expect(button.getAttribute('title')).toBe('input empty');
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('title', 'input empty');
   });
 
   test('should disable submit for invalid input', async () => {
@@ -144,8 +140,8 @@ describe('Home', () => {
     const button = screen.getByRole('button', { name: 'submit' }) as HTMLButtonElement;
 
     await userEvent.type(inputField, 'a'.repeat(257));
-    expect(button.disabled).toBe(true);
-    expect(button.getAttribute('title')).toBe('input too long');
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('title', 'input too long');
   });
 
   test('should throttle submissions to 1 per 30 seconds', async () => {
@@ -157,13 +153,13 @@ describe('Home', () => {
     fireEvent.click(button);
 
     await waitFor(() => {
-      expect(screen.getByTestId('ai')).not.toBeNull();
+      expect(screen.getByTestId('ai')).toBeInTheDocument();
     });
 
     await userEvent.type(inputField, 'second idea');
     fireEvent.click(button);
 
-    expect(button.getAttribute('title')).toMatch(/please wait/i);
+    expect(button).toHaveAttribute('title', expect.stringMatching(/please wait/i));
 
     jest.restoreAllMocks();
   });
@@ -180,7 +176,7 @@ describe('Home', () => {
     fireEvent.click(button);
 
     await waitFor(() => {
-      expect(screen.getByTestId('ai')).not.toBeNull();
+      expect(screen.getByTestId('ai')).toBeInTheDocument();
     });
 
     now += 31_000;
@@ -190,12 +186,12 @@ describe('Home', () => {
     fireEvent.click(button);
 
     await waitFor(() => {
-      expect(inputField.value).toBe('');
+      expect(inputField).toHaveValue('');
     });
 
-    expect(screen.getByTestId('user').textContent).toBe('second');
+    expect(screen.getByTestId('user')).toHaveTextContent('second');
     await waitFor(() => {
-      expect(screen.getByTestId('ai')).not.toBeNull();
+      expect(screen.getByTestId('ai')).toBeInTheDocument();
     });
     jest.restoreAllMocks();
   });


### PR DESCRIPTION
## Summary
Refactor unit/integration tests with jest-dom for critique App.

## Description
Refactor unit/integration tests with jest-dom for critique App. Jest and React Testing Library are used for dom selection and manipulation currently.  

## Changes
- Refactor unit/integration tests with jest-dom instead of RTL

Details
- Idioms and recommendations use jest-dom for element selection primarily

## Constraints
- Install and use `jest-dom` and `types/jest`

## Criteria
- Given an unit or integration test, when the test selects a dom element, then jest dom makes the selection

Tests
Run Unit/Integration Tests
1. Run `npm run test -- --coverage`
- Tests Pass