### PR TITLE
Fallback to Predetermined Ideas with ideate CLI Option

### DIFF
--- a/ideate/cli/ideate.py
+++ b/ideate/cli/ideate.py
@@ -24,6 +24,12 @@ def ideate(
         help="Selects ideation topic.",
         autocompletion=autocomplete_topics,
     ),
+    fallback: bool = typer.Option(
+        False,
+        "--fallback",
+        "-f",
+        help="Forces fallback idea.",
+    ),
 ) -> None:
     """
     Generates a creative idea, by topic optionally, with a simulated thinking delay.
@@ -42,10 +48,13 @@ def ideate(
 
     _thinking_delay()
 
-    idea, error, status = get_ai_idea(canonical_topic)
-    _ = error
-    if status != 200 or not idea:
+    if fallback:
         idea = get_fallback_idea()
+    else:
+        idea, error, status = get_ai_idea(canonical_topic)
+        _ = error
+        if status != 200 or not idea:
+            idea = get_fallback_idea()
     if canonical_topic:
         typer.echo(f"{canonical_topic} Idea: {idea}")
     else:

--- a/ideate/tests/cli/ideate_test.py
+++ b/ideate/tests/cli/ideate_test.py
@@ -80,6 +80,46 @@ def test_ideate_cli_fallback_secondary_no_topic() -> None:
         assert result.exit_code == 0
         assert result.output.strip() in responses
 
+def test_ideate_cli_fallback_option_no_topic() -> None:
+    """
+    Tests ideate CLI prints fallback idea when --fallback is used without topic.
+    """
+    result = runner.invoke(app, ["ideate", "--fallback"])
+
+    assert result.exit_code == 0
+    assert result.output.strip() in responses
+
+def test_ideate_cli_fallback_option_with_topic() -> None:
+    """
+    Tests ideate CLI prints fallback idea with topic when --fallback is used.
+    """
+    topic = topics[1]
+    result = runner.invoke(app, ["ideate", "--fallback", "--topic", topic])
+
+    assert result.exit_code == 0
+    assert result.output.startswith(f"{topic} Idea:")
+    assert any(resp in result.output for resp in responses)
+
+def test_ideate_cli_fallback_short_flag() -> None:
+    """
+    Tests ideate CLI prints fallback idea when -f is used.
+    """
+    result = runner.invoke(app, ["ideate", "-f"])
+
+    assert result.exit_code == 0
+    assert result.output.strip() in responses
+
+def test_ideate_cli_fallback_short_flag_with_topic() -> None:
+    """
+    Tests ideate CLI prints fallback idea with topic when -f -t is used.
+    """
+    topic = topics[2]
+    result = runner.invoke(app, ["ideate", "-f", "-t", topic])
+
+    assert result.exit_code == 0
+    assert result.output.startswith(f"{topic} Idea:")
+    assert any(resp in result.output for resp in responses)
+
 def test_ideate_cli_help() -> None:
     """
     Tests ideate CLI help command.


### PR DESCRIPTION
## Summary
Falls back to Predetermined Ideas with ideate CLI Option to avoid intelligent response via GitHub Models API and OpenAI SDK.

## Description
Falls back to Predetermined Ideas with ideate CLI Option so that there is a way to not generate an intelligent response via GitHub Models API and OpenAI SDK.  Passes a topic if provided by CLI and use the fallback option. 

## Changes
- Creates fallback, f, option for the ideate CLI ideate command
- Checks for fallback option and when set do not get ai idea

## Criteria
- Given fallback option exists for the ideate command, when fallback option is used, the output is an idea from fallback response
- Given fallback option is used, when user requests an idea with or without a topic, output is an idea from fallback response with topic

## Tests
Prints Fallback Idea and Generates AI Idea with ideate command options
1. Run `cd /workspaces/stacked/ideate && source .ideate/bin/activate`
  - Activates environment (.ideate)
2. Run `pylint ideate && pytest ideate/tests`
  - Lint without errors 
  - Tests without failures
3. Run `cd /workspaces/stacked`
  - Changes directory to `stacked` for `ideate.cli.ideate`
4. Run `python3 -m ideate.cli.ideate ideate --fallback`
  - Outputs `An umbrella that appears when it rains`
5. Run `python3 -m ideate.cli.ideate ideate -f`
  - Outputs `An umbrella that appears when it rains`
6. Run `python3 -m ideate.cli.ideate ideate --fallback --topic Art`
  - Outputs `Art Idea: A pen that never runs out of ink`
7. Run `python3 -m ideate.cli.ideate ideate -ft Art`
  - Outputs `Art Idea: A pen that never runs out of ink`
8. Run `python3 -m ideate.cli.ideate ideate`
  - Outputs `An idea that is not in the fallback responses`
9. Run `python3 -m ideate.cli.ideate ideate --topic Art`
  - Outputs `Art Idea: An idea that is not in the fallback responses`

### Quicktest
```
cd /workspaces/stacked/ideate && source .ideate/bin/activate && cd .. && python3 -m ideate.cli.ideate ideate --fallback && python3 -m ideate.cli.ideate ideate -f && python3 -m ideate.cli.ideate ideate --fallback --topic Art && python3 -m ideate.cli.ideate ideate -ft Art && python3 -m ideate.cli.ideate ideate && python3 -m ideate.cli.ideate ideate --topic Art
```
